### PR TITLE
Update BlockFile::CalcSummary reference URL

### DIFF
--- a/src/waveform-generator.js
+++ b/src/waveform-generator.js
@@ -2,7 +2,7 @@
  * AudioBuffer-based WaveformData generator
  *
  * Adapted from BlockFile::CalcSummary in Audacity, with permission.
- * See https://code.google.com/p/audacity/source/browse/audacity-src/trunk/src/BlockFile.cpp
+ * See https://github.com/audacity/audacity/blob/1108c1376c09166162335fab4743008cba57c4ee/src/BlockFile.cpp#L198
  */
 
  var INT8_MAX = 127;


### PR DESCRIPTION
The original link to audacity source repository is outdated, I replaced it with a link to the audacity github repository. As the file does not exists anymore I linked to the last commit of the specific file.